### PR TITLE
Refactor cmesh files structure

### DIFF
--- a/cmesh/src/cmesh.cpp
+++ b/cmesh/src/cmesh.cpp
@@ -1,4 +1,4 @@
-#include "cmesh.h"
+#include "cmesh/vsgf_loader.h"
 
 #include <cmath>
 #include <cfloat>

--- a/cmesh/src/cmesh_weld.cpp
+++ b/cmesh/src/cmesh_weld.cpp
@@ -1,4 +1,4 @@
-#include "cmesh.h"
+#include "cmesh/vsgf_loader.h"
 
 #include "LiteMath.h"
 using LiteMath::float4;

--- a/cvex_proj.vcxproj
+++ b/cvex_proj.vcxproj
@@ -22,32 +22,32 @@
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{5B25EF36-2B2E-44D9-A0ED-C8E04F19368F}</ProjectGuid>
     <RootNamespace>cvexproj</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
@@ -70,10 +70,10 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <IncludePath>.;$(IncludePath)</IncludePath>
+    <IncludePath>.;include;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <IncludePath>.;$(IncludePath)</IncludePath>
+    <IncludePath>.;include;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
@@ -128,6 +128,8 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="cmesh\src\cmesh.cpp" />
+    <ClCompile Include="cmesh\src\cmesh_weld.cpp" />
     <ClCompile Include="main.cpp" />
     <ClCompile Include="tests\tests_all.cpp" />
     <ClCompile Include="tests\tests_vfloat4.cpp" />

--- a/cvex_proj.vcxproj.filters
+++ b/cvex_proj.vcxproj.filters
@@ -27,6 +27,12 @@
     <ClCompile Include="tests\tests_vmatrix4.cpp">
       <Filter>Исходные файлы</Filter>
     </ClCompile>
+    <ClCompile Include="cmesh\src\cmesh.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="cmesh\src\cmesh_weld.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="include\vfloat4_x64.h">
@@ -41,11 +47,11 @@
     <ClInclude Include="include\vfloat4.h">
       <Filter>Файлы заголовков</Filter>
     </ClInclude>
-    <ClInclude Include="include\litemath.h">
-      <Filter>Файлы заголовков</Filter>
-    </ClInclude>
     <ClInclude Include="include\LiteMath.h">
       <Filter>Исходные файлы</Filter>
+    </ClInclude>
+    <ClInclude Include="include\lite_math.h">
+      <Filter>Файлы заголовков</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/include/cmesh/simple_mesh.h
+++ b/include/cmesh/simple_mesh.h
@@ -2,13 +2,10 @@
 // Created by frol on 23.11.19. //
 //////////////////////////////////
 
-#ifndef CMESH_GEOM_H
-#define CMESH_GEOM_H
+#ifndef CMESH_SIMPLE_MESH_H
+#define CMESH_SIMPLE_MESH_H
 
 #include <vector>
-#include <stdexcept>
-#include <sstream>
-#include <memory>
 #include <cassert>
 
 #include "LiteMath.h"
@@ -38,8 +35,8 @@ namespace cmesh
       vTang4f.resize(a_vertNum);
       vTexCoord2f.resize(a_vertNum);
       indices.resize(a_indNum);
-      matIndices.resize(a_indNum/3); 
-      assert(a_indNum%3 == 0); // PLEASE NOTE THAT CURRENT IMPLEMENTATION ASSUME ONLY TRIANGLE MESHES! 
+      matIndices.resize(a_indNum / POINTS_IN_TRIANGLE);
+      assert(a_indNum % POINTS_IN_TRIANGLE == 0); // PLEASE NOTE THAT CURRENT IMPLEMENTATION ASSUME ONLY TRIANGLE MESHES! 
     };
 
     inline size_t SizeInBytes() const
@@ -69,18 +66,8 @@ namespace cmesh
     std::vector<unsigned int>                 matIndices;  // size = 1*TrianglesNum()
   };
 
-#if defined(__ANDROID__)
-  SimpleMesh LoadMeshFromVSGF(AAssetManager* mgr, const char* a_fileName);
-#else
-  SimpleMesh LoadMeshFromVSGF(const char* a_fileName);
-#endif
-  void       SaveMeshToVSGF  (const char* a_fileName, const SimpleMesh& a_mesh);
-  SimpleMesh LoadMeshViaAssimp(const char* a_fileName);
-
-  SimpleMesh CreateQuad(const int a_sizeX, const int a_sizeY, const float a_size);
-
   void WeldVertices(SimpleMesh& mesh, int indexNum);
 };
 
 
-#endif // CMESH_GEOM_H
+#endif // CMESH_SIMPLE_MESH_H

--- a/include/cmesh/vsgf_loader.h
+++ b/include/cmesh/vsgf_loader.h
@@ -1,0 +1,24 @@
+//////////////////////////////////
+// Created by frol on 23.11.19. //
+//////////////////////////////////
+
+#ifndef CMESH_VSGF_LOADER_H
+#define CMESH_VSGF_LOADER_H
+
+#include "simple_mesh.h"
+
+namespace cmesh
+{
+
+#if defined(__ANDROID__)
+  SimpleMesh LoadMeshFromVSGF(AAssetManager* mgr, const char* a_fileName);
+#else
+  SimpleMesh LoadMeshFromVSGF(const char* a_fileName);
+#endif
+  void       SaveMeshToVSGF  (const char* a_fileName, const SimpleMesh& a_mesh);
+
+  SimpleMesh CreateQuad(const int a_sizeX, const int a_sizeY, const float a_size);
+};
+
+
+#endif // CMESH_VSGF_LOADER_H

--- a/main.cpp
+++ b/main.cpp
@@ -1,11 +1,12 @@
 #include <iostream>
 #include "include/LiteMath.h"
-
+#include "cmesh/vsgf_loader.h"
 
 #include "tests/tests.h"
 
 int main(int argc, const char** argv)
 {
   run_all_tests();
+  // auto mesh = cmesh::LoadMeshFromVSGF("chunk_00005.vsgf"); Set your filename here for load test.
   return 0;
 }


### PR DESCRIPTION
Split simple mesh declaration and vsgf loading function.
Remove unused includes.
Remove assimp loading function declaration.
Move files to cmesh subdirectories.

This refactor is necessary to support glTF format loading later.